### PR TITLE
fix: add tileSize to style.json and render tiles in EPSG:3857 (#16)

### DIFF
--- a/comapeo_smp_generator.py
+++ b/comapeo_smp_generator.py
@@ -156,9 +156,12 @@ class TileCache:
             try:
                 with open(path) as fh:
                     data = json.load(fh)
-                # Schema migration: discard old-format caches that lack
-                # source_index in their keys.
-                if data.get('schema_version', 0) < 2:
+                # Schema migration: discard caches from older versions.
+                #   v2: added source_index to tile keys.
+                #   v3: tiles now rendered in EPSG:3857 (was project CRS), so
+                #       tiles cached before the fix have stale pixel content
+                #       even though their fingerprint still matches.
+                if data.get('schema_version', 0) < 3:
                     return {}
                 return data
             except (json.JSONDecodeError, OSError):
@@ -174,7 +177,7 @@ class TileCache:
         try:
             with open(tmp_path, 'w') as fh:
                 meta = dict(self._state['meta'])
-                meta['schema_version'] = 2
+                meta['schema_version'] = 3
                 json.dump(meta, fh)
             os.replace(tmp_path, self._meta_path)
         except Exception:
@@ -1384,6 +1387,7 @@ class SMPGenerator:
                 "name": source_name,
                 "version": "2.0",
                 "type": "raster",
+                "tileSize": 256,
                 "minzoom": export_zooms[0],
                 "maxzoom": export_zooms[-1],
                 "scheme": "xyz",
@@ -1665,9 +1669,26 @@ class SMPGenerator:
         # Get the current project
         project = QgsProject.instance()
 
-        # Create map settings for rendering
+        # Create map settings for rendering.
+        #
+        # Tiles must be rendered in EPSG:3857 (Web Mercator) — the projection
+        # MapLibre uses to display XYZ tiles.  Rendering in the project CRS
+        # (often a UTM zone for field projects) introduces projection
+        # distortion and misaligns tile pixels against MapLibre's Mercator
+        # base.  QGIS reprojects all layers from their source CRS to 3857 on
+        # the fly during rendering.
+        web_mercator = QgsCoordinateReferenceSystem("EPSG:3857")
+        if not web_mercator.isValid():
+            raise RuntimeError("Could not construct the EPSG:3857 CRS")
+        project_to_3857 = QgsCoordinateTransform(
+            project.crs(), web_mercator, project)
+        if not project_to_3857.isValid():
+            raise RuntimeError(
+                "Cannot reproject project CRS '{}' to EPSG:3857. Tiles must "
+                "be rendered in Web Mercator; use a project CRS that can "
+                "transform to EPSG:3857.".format(project.crs().authid()))
         map_settings = QgsMapSettings()
-        map_settings.setDestinationCrs(project.crs())
+        map_settings.setDestinationCrs(web_mercator)
 
         # Add visible layers in layer-tree order (matches what users see in the
         # QGIS layer panel) so that rendering is deterministic across Processing
@@ -2179,7 +2200,7 @@ class SMPGenerator:
         :param xtile: Tile X coordinate
         :param ytile: Tile Y coordinate
         :param zoom: Zoom level
-        :return: QgsRectangle in project CRS
+        :return: QgsRectangle in EPSG:3857
         """
         # Get WGS84 bounds for this tile (NW corner)
         north, west = self._num2deg(xtile, ytile, zoom)
@@ -2189,10 +2210,12 @@ class SMPGenerator:
         # Create rectangle in WGS84
         wgs84_rect = QgsRectangle(west, south, east, north)
 
-        # Transform to project CRS
+        # Transform to EPSG:3857 — the CRS tiles are rendered in (see
+        # _generate_tiles_from_canvas).  The tile extent must match the render
+        # CRS so each XYZ tile covers exactly its Web Mercator cell.
         wgs84 = QgsCoordinateReferenceSystem("EPSG:4326")
-        project_crs = QgsProject.instance().crs()
-        transform = QgsCoordinateTransform(wgs84, project_crs, QgsProject.instance())
+        web_mercator = QgsCoordinateReferenceSystem("EPSG:3857")
+        transform = QgsCoordinateTransform(wgs84, web_mercator, QgsProject.instance())
 
         return transform.transformBoundingBox(wgs84_rect)
 

--- a/comapeo_smp_generator.py
+++ b/comapeo_smp_generator.py
@@ -312,6 +312,11 @@ class SMPGenerator:
         :param feedback: Feedback object for progress reporting
         """
         self.feedback = feedback
+        # CRS objects are immutable and safe to share across the render
+        # thread pool.  Build them once per generator instead of on every
+        # _calculate_tile_extent call (one per tile).
+        self._wgs84_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+        self._web_mercator_crs = QgsCoordinateReferenceSystem("EPSG:3857")
 
     def log(self, message, level=Qgis.Info):
         """
@@ -1677,13 +1682,13 @@ class SMPGenerator:
         # distortion and misaligns tile pixels against MapLibre's Mercator
         # base.  QGIS reprojects all layers from their source CRS to 3857 on
         # the fly during rendering.
-        web_mercator = QgsCoordinateReferenceSystem("EPSG:3857")
+        web_mercator = self._web_mercator_crs
         if not web_mercator.isValid():
-            raise RuntimeError("Could not construct the EPSG:3857 CRS")
+            raise ValueError("Could not construct the EPSG:3857 CRS")
         project_to_3857 = QgsCoordinateTransform(
             project.crs(), web_mercator, project)
         if not project_to_3857.isValid():
-            raise RuntimeError(
+            raise ValueError(
                 "Cannot reproject project CRS '{}' to EPSG:3857. Tiles must "
                 "be rendered in Web Mercator; use a project CRS that can "
                 "transform to EPSG:3857.".format(project.crs().authid()))
@@ -2213,9 +2218,13 @@ class SMPGenerator:
         # Transform to EPSG:3857 — the CRS tiles are rendered in (see
         # _generate_tiles_from_canvas).  The tile extent must match the render
         # CRS so each XYZ tile covers exactly its Web Mercator cell.
-        wgs84 = QgsCoordinateReferenceSystem("EPSG:4326")
-        web_mercator = QgsCoordinateReferenceSystem("EPSG:3857")
-        transform = QgsCoordinateTransform(wgs84, web_mercator, QgsProject.instance())
+        #
+        # Re-use the cached, immutable CRS objects (safe to share across the
+        # render thread pool).  The transform itself is built per call: this
+        # method runs concurrently in the worker pool and QgsCoordinateTransform
+        # is not safe to share between threads.
+        transform = QgsCoordinateTransform(
+            self._wgs84_crs, self._web_mercator_crs, QgsProject.instance())
 
         return transform.transformBoundingBox(wgs84_rect)
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=CoMapeo Map Builder
 qgisMinimumVersion=3.0
 description=Generates SMP files for CoMapeo using proper XYZ Web Mercator tiling
-version=0.8.0
+version=0.8.1
 author=Awana Digital
 email=luandro@awana.digital
 
@@ -20,6 +20,11 @@ repository=https://github.com/digidem/qgis-smp-plugin
 
 hasProcessingProvider=yes
 changelog=
+    0.8.1 - Fix blurry tiles: declare tileSize and render in EPSG:3857
+    * Add "tileSize": 256 to style.json sources so MapLibre stops upscaling tiles (fixes blur and clipped labels)
+    * Render tiles in EPSG:3857 (Web Mercator) instead of the project CRS to remove projection distortion and misalignment
+    * Validate the project->EPSG:3857 transform and fail with a clear message for unsupported CRSs
+    * Bump tile cache schema to 3 to discard tiles cached in the old project CRS
     0.8.0 - Fixed world/region/local SMP source model
     * Implement fixed-slot source model: world=s/0, region=s/1, local=s/2
     * Add optional Region detail source with extent and zoom bounds

--- a/scripts/test-qgis-headless.py
+++ b/scripts/test-qgis-headless.py
@@ -75,6 +75,9 @@ for lon, lat, name in [(-5, 5, "A"), (5, 5, "B"), (0, -5, "C")]:
     pr.addFeature(f)
 layer.updateExtents()
 QgsProject.instance().addMapLayer(layer)
+# Real QGIS projects always carry a CRS; set one explicitly so tile
+# rendering can build a valid project->EPSG:3857 transform (issue #16).
+QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
 extent = layer.extent()
 gen = SMPGenerator()
 
@@ -88,6 +91,30 @@ try:
     check("WGS84 bounds has 4 floats", len(bounds) == 4)
     check("West < East", bounds[0] < bounds[2])
     check("South < North", bounds[1] < bounds[3])
+
+    # ------------------------------------------------------------------
+    print("\n--- Tile Render CRS = EPSG:3857 (issue #16) ---")
+
+    # With a UTM project CRS, tiles must still be rendered in EPSG:3857.
+    # _calculate_tile_extent must therefore return Web Mercator metres,
+    # independent of the project CRS — proven here with a real transform.
+    orig_crs = QgsProject.instance().crs()
+    QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:32723"))  # UTM 23S
+    try:
+        te = gen._calculate_tile_extent(0, 0, 0)  # whole-world tile
+        # EPSG:3857 world half-extent ≈ 20 037 508 m; UTM eastings are
+        # ~10^5–10^6 and degrees are <360, so the metre range is decisive.
+        x_ok = 1e6 < abs(te.xMinimum()) < 2.1e7 and 1e6 < abs(te.xMaximum()) < 2.1e7
+        y_ok = 1e6 < abs(te.yMinimum()) < 2.1e7 and 1e6 < abs(te.yMaximum()) < 2.1e7
+        check("Tile extent X in EPSG:3857 metre range (not UTM/degrees)", x_ok,
+              "got x [{}, {}]".format(te.xMinimum(), te.xMaximum()))
+        check("Tile extent Y in EPSG:3857 metre range", y_ok,
+              "got y [{}, {}]".format(te.yMinimum(), te.yMaximum()))
+        style_utm = gen._create_style_from_canvas(extent, 0, 10, 'PNG')
+        check("style source declares tileSize 256 under UTM project",
+              all(s.get('tileSize') == 256 for s in style_utm['sources'].values()))
+    finally:
+        QgsProject.instance().setCrs(orig_crs)
 
     # ------------------------------------------------------------------
     print("\n--- Tile Math ---")

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -83,6 +83,9 @@ class _FakeTransform:
         # Return the same rectangle (pretend project CRS == WGS84 for tests)
         return rect
 
+    def isValid(self):
+        return True
+
 
 # Patch the qgis modules before importing the generator
 import sys
@@ -1002,6 +1005,24 @@ class TestCreateStyleJson(unittest.TestCase):
         source = list(style['sources'].values())[0]
         self.assertIn('bounds', source)
         self.assertEqual(len(source['bounds']), 4)
+
+    def test_style_source_declares_tile_size_256(self):
+        # MapLibre's raster source defaults to tileSize 512.  The plugin
+        # renders 256px tiles, so every source must declare tileSize:256 or
+        # MapLibre displays zoom N-1 content at zoom N (blurry, clipped
+        # labels).  Regression guard for issue #16.
+        style = self.gen._create_style_from_canvas(self._make_extent(), 0, 10)
+        self.assertTrue(style['sources'])
+        for source in style['sources'].values():
+            self.assertEqual(source['tileSize'], 256)
+
+    def test_multi_source_styles_declare_tile_size_256(self):
+        style = self.gen._create_style_from_canvas(
+            self._make_extent(), 6, 12,
+            include_world_base_zooms=True, world_max_zoom=3)
+        self.assertGreaterEqual(len(style['sources']), 2)
+        for source in style['sources'].values():
+            self.assertEqual(source['tileSize'], 256)
 
     def test_style_zoom_levels(self):
         style = self.gen._create_style_from_canvas(self._make_extent(), 3, 15)
@@ -5016,15 +5037,51 @@ class TestCacheSchemaMigration(unittest.TestCase):
         self.assertFalse(cache.is_fresh(0, 0, 0, fp))
 
     def test_schema_version_1_treated_as_stale(self):
-        """Cache meta with schema_version < 2 should be treated as stale."""
+        """Cache meta with schema_version < 3 should be treated as stale."""
         import json
         meta_path = os.path.join(self.tmp, TileCache.META_FILE)
         with open(meta_path, 'w') as f:
-            json.dump({"schema_version": 1, "0/0/0": "PNG:85:fp1"}, f)
+            json.dump({"schema_version": 1, "0/0/0/0": "PNG:85:fp1"}, f)
 
         cache = TileCache(self.tmp)
         fp = TileCache.make_fingerprint('PNG', 85, 'fp1')
         self.assertFalse(cache.is_fresh(0, 0, 0, fp))
+
+    def test_schema_version_2_treated_as_stale(self):
+        """v2 caches rendered tiles in the project CRS.  After the EPSG:3857
+        fix (issue #16) those pixels are stale even though their fingerprint
+        still matches, so a v2 cache must be discarded."""
+        import json
+        meta_path = os.path.join(self.tmp, TileCache.META_FILE)
+        with open(meta_path, 'w') as f:
+            json.dump({"schema_version": 2, "0/0/0/0": "PNG:85:fp1"}, f)
+
+        cache = TileCache(self.tmp)
+        fp = TileCache.make_fingerprint('PNG', 85, 'fp1')
+        self.assertFalse(cache.is_fresh(0, 0, 0, fp))
+
+    def test_schema_version_3_is_fresh(self):
+        """A current (v3) cache entry with a matching fingerprint is fresh."""
+        import json
+        fp = TileCache.make_fingerprint('PNG', 85, 'fp1')
+        meta_path = os.path.join(self.tmp, TileCache.META_FILE)
+        with open(meta_path, 'w') as f:
+            json.dump({"schema_version": 3, "0/0/0/0": fp}, f)
+
+        cache = TileCache(self.tmp)
+        self.assertTrue(cache.is_fresh(0, 0, 0, fp))
+
+    def test_save_writes_schema_version_3(self):
+        """Persisted cache metadata must carry the current schema version."""
+        import json
+        cache = TileCache(self.tmp)
+        fp = TileCache.make_fingerprint('PNG', 85, 'fp1')
+        cache.mark(0, 0, 0, fp)  # defer_save=False persists immediately
+
+        meta_path = os.path.join(self.tmp, TileCache.META_FILE)
+        with open(meta_path) as f:
+            data = json.load(f)
+        self.assertEqual(data['schema_version'], 3)
 
 
 class TestRenderSingleTileSourceIndex(unittest.TestCase):

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -45,7 +45,11 @@ class _FakeRectangle:
 
 
 class _FakeCrs:
-    pass
+    def authid(self):
+        return 'EPSG:4326'
+
+    def isValid(self):
+        return True
 
 
 class _FakeProject:
@@ -1422,6 +1426,27 @@ class TestParallelTileRendering(unittest.TestCase):
                 )
             # img.save should have been called 4 times (2x2 tile grid)
             self.assertEqual(fake_img.save.call_count, 4)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestRenderCrsGuard(unittest.TestCase):
+    """The project->EPSG:3857 guard must raise ValueError so the Processing
+    algorithm (which catches ValueError/OSError) can surface a clean error
+    instead of an unhandled exception for unsupported project CRSs."""
+
+    def test_invalid_transform_raises_value_error(self):
+        import comapeo_smp_generator as _mod
+        gen = SMPGenerator()
+        invalid_tf = MagicMock()
+        invalid_tf.isValid.return_value = False
+        tmp = tempfile.mkdtemp()
+        try:
+            with patch.object(_mod, 'QgsProject', _FakeProject), \
+                 patch.object(_mod, 'QgsCoordinateTransform', return_value=invalid_tf):
+                with self.assertRaises(ValueError):
+                    gen._generate_tiles_from_canvas(
+                        _FakeRectangle(-1, -1, 1, 1), 0, 0, tmp, tile_format='PNG')
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
 


### PR DESCRIPTION
## Summary

Fixes #16. SMP maps exported for CoMapeo rendered **blurry with clipped labels** on field devices, even at max quality. Two rendering bugs were responsible:

1. **Missing `tileSize` in style.json (primary blur cause).** The plugin renders 256×256 tiles but the generated style.json omitted `tileSize`. MapLibre defaults raster sources to **512px**, so it upscaled each 256px tile 2× and displayed zoom *N-1* content at zoom *N* — blur and truncated labels.
2. **Tiles rendered in the project CRS instead of EPSG:3857.** For field projects the project CRS is usually a UTM zone. XYZ/MapLibre expect Web Mercator, so rendering in UTM caused projection distortion and misalignment against MapLibre's base.

## Changes

- Add `"tileSize": 256` to every raster source in `_create_style_from_canvas`.
- Render tiles in **EPSG:3857** (`_generate_tiles_from_canvas`) and transform tile extents to 3857 in `_calculate_tile_extent` so each tile covers exactly its Web Mercator cell.
- Validate the project→EPSG:3857 transform up front and raise `ValueError` (caught by the Processing algorithm → clean error) for CRSs that cannot be reprojected.
- Cache the WGS84/EPSG:3857 CRS objects once per generator (the transform stays per-call for thread safety).
- Bump `TileCache` schema **2 → 3** so tiles cached in the old project CRS are discarded on upgrade (their fingerprint would otherwise still match).
- Tests: `tileSize:256` assertions, cache-schema v2-stale / v3-fresh / save-writes-3, a CRS-guard regression test, and a headless QGIS check that tile extents are in EPSG:3857 under a UTM project.
- `metadata.txt`: bump to **0.8.1** with changelog entry.

Out of scope (separate PR, per the issue): the optional 256/512 “Tile resolution” enhancement.

## Verification
<img width="2596" height="826" alt="compare_z1" src="https://github.com/user-attachments/assets/f5bae425-e7af-44d7-9202-9e7551403f66" />
<img width="2596" height="826" alt="compare_z2" src="https://github.com/user-attachments/assets/db480ef9-b458-4a00-a4c6-cbcfdb320871" />
<img width="2596" height="826" alt="compare_z3" src="https://github.com/user-attachments/assets/1a37419d-5ea8-4af9-9ef7-baba3e665e5c" />

- Offline tests: **280/280 pass** (`make test`).
- Headless QGIS (real CRS transforms): **56/56 pass** (`scripts/test-qgis-headless.py`).
- Lint: **`make flake8` clean** (CI gate).
- **Live round-trip**: reprojected a real field project (Caru, Maranhão) to UTM 23S, exported a `before` SMP (current code) and `after` SMP (this branch) over a village area at z12–17, then compared in [smp-viewer.pages.dev](https://smp-viewer.pages.dev/) (MapLibre — the same renderer CoMapeo uses). `before` had no `tileSize`; `after` declares `tileSize: 256`.

Before/after screenshots from the SMP viewer (matched zoom & location) are attached in a comment below.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two distinct rendering bugs that caused blurry, distortion-affected tiles on CoMapeo field devices: a missing `tileSize: 256` declaration in `style.json` (making MapLibre upscale each 256 px tile 2×) and tiles being rendered in the project CRS (often a UTM zone) instead of EPSG:3857. A cache schema bump to v3 ensures stale project-CRS pixels are automatically discarded on upgrade.

- **`_create_style_from_canvas`**: adds `"tileSize": 256` to every raster source entry so MapLibre stops assuming the 512 px default.
- **`_generate_tiles_from_canvas` / `_calculate_tile_extent`**: render destination switched to EPSG:3857; tile extents now transform WGS84 → 3857 (previously project CRS); thread safety maintained by caching immutable CRS objects in `__init__` and building `QgsCoordinateTransform` per call.
- **Tests**: 279 offline tests + 56 headless QGIS tests extended to cover `tileSize`, cache schema v2-stale/v3-fresh, the CRS-guard `ValueError`, and a real UTM → 3857 extent check.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both rendering bugs are fixed with targeted, well-scoped changes backed by 335 passing tests.

The two root causes (missing tileSize and wrong render CRS) are addressed directly. Thread safety is handled correctly: immutable CRS objects are cached once in __init__, while QgsCoordinateTransform is built per call to avoid concurrent access issues. The cache schema bump correctly invalidates stale project-CRS tiles. Test coverage is thorough, including a headless QGIS run with a real UTM to 3857 transform, regression guards for tileSize, and the full cache schema lifecycle.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| comapeo_smp_generator.py | Core rendering logic updated: tileSize:256 added to style sources, destination CRS switched to EPSG:3857, tile extents now WGS84 to 3857, thread-safe CRS caching in __init__, cache schema bumped to v3. |
| test/test_generator.py | New tests for tileSize assertion, cache schema v2-stale/v3-fresh/save-writes-3, and the CRS-guard ValueError path; _FakeCrs and _FakeTransform updated with isValid() stubs needed by the new guard check. |
| scripts/test-qgis-headless.py | Project CRS set to EPSG:4326 before generator construction; new UTM 23S block verifies tile extents land in EPSG:3857 metre range and style sources carry tileSize:256 regardless of project CRS. |
| metadata.txt | Version bumped to 0.8.1 with changelog entry describing all four changes in this fix. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: raise ValueError (not RuntimeError)..."](https://github.com/digidem/qgis-smp-plugin/commit/4ae4bb064d0e2375691eedfab97e7b56d018f83f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35428588)</sub>

<!-- /greptile_comment -->