### PR TITLE
allow to be used in qgis4 and some minimum API changes

### DIFF
--- a/comapeo_smp_generator.py
+++ b/comapeo_smp_generator.py
@@ -1595,11 +1595,11 @@ class SMPGenerator:
 
         tile_size = 256
         if tile_format == self.TILE_FORMAT_JPG:
-            img = QImage(tile_size, tile_size, QImage.Format_RGB32)
+            img = QImage(tile_size, tile_size, QImage.Format.Format_RGB32)
             img.fill(0xFFFFFFFF)
         else:
             # PNG and WebP both support transparency
-            img = QImage(tile_size, tile_size, QImage.Format_ARGB32)
+            img = QImage(tile_size, tile_size, QImage.Format.Format_ARGB32)
             img.fill(0)
 
         painter = QPainter(img)

--- a/metadata.txt
+++ b/metadata.txt
@@ -5,6 +5,7 @@
 [general]
 name=CoMapeo Map Builder
 qgisMinimumVersion=3.0
+qgisMaximumVersion=4.99
 description=Generates SMP files for CoMapeo using proper XYZ Web Mercator tiling
 version=0.8.1
 author=Awana Digital


### PR DESCRIPTION
QGIS moved to version 4 which breaks the plugin, the main change is the move to QT5 to QT6 and its python bindings. 
The code published as plugin differs from the repo, so I only added changes to the code that I knew that needed changes, but don't know if code breaks in other places. 
Also I dunno if we could publish 2 versions of the plugin if we want to mantain backwards compatibilty with QGIS3

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates tile image-format enum access for Qt6 and expands the advertised maximum QGIS version to 4.99 while retaining QGIS 3.0 as the minimum supported version.

QGIS 3 compatibility remains at risk because tile rendering uses the Qt6-scoped `QImage.Format` enum spelling, which is not the PyQt5 API shape.

### T-Rex validation blocked
- **Missing package:** The required `PyQt5` and `qgis` Python bindings are unavailable in both the sandbox and system Python. The direct image-format probe could not import either binding, so the QGIS 3 tile-rendering path could not be executed.

<h3>Confidence Score: 4/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the PyQt5/QGIS enum probe to inspect QImage.Format and related enum paths.
- The probe failed with ModuleNotFoundError for PyQt5 and for qgis, blocking execution.
- A separate system Python availability check confirmed that PyQt5 and qgis bindings are not installed in this environment.
- The probe description was documented to specify the exact access pattern needed to validate the nested enum and potential AttributeError with a compatible binding.
- Artifacts were gathered to support review, including the probe source and the runtime availability outputs.

<a href="https://app.greptile.com/trex/runs/16913745/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
comapeo_smp_generator.py:1598
**Scoped enums break QGIS 3**

When a QGIS 3 user generates an SMP, the renderer evaluates the PyQt6-scoped `QImage.Format.Format_RGB32` or `QImage.Format.Format_ARGB32` enum even though PyQt5 exposes these values directly on `QImage`, causing tile rendering to raise `AttributeError` for every supported output format.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["allow to be used in qgis4 and some minim..."](https://github.com/digidem/qgis-smp-plugin/commit/e2d7c11289c2059317754791f03f2b07b24dc28f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49376802)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->